### PR TITLE
Replace binary JPG assets with SVG placeholders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+node_modules/
+backend/node_modules/
+frontend/node_modules/
+backend/.env
+frontend/.env
+.env
+backend/uploads/
+frontend/dist/
+frontend/.vite/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,62 +1,145 @@
-# Site Web d'Église
+# TFMI — Site d'église MERN
 
-Ce projet est une version simplifiée d'un site web d'église, créé avec HTML, CSS et JavaScript natif. Il offre une interface moderne et responsive sans dépendre d'une base de données.
+Refonte complète du site de Triumphant Faith Ministries International (TFMI) en stack MERN avec un **frontend React (Vite + Tailwind)** et un **backend Node/Express + MongoDB**.
 
-## Fonctionnalités
+## ✨ Fonctionnalités
 
-- Design responsive
-- Menu de navigation mobile
-- Sections pour les services et événements
-- Animations au défilement
-- Intégration des réseaux sociaux
-- Défilement fluide pour la navigation
+### Frontend (public)
+- Accueil avec hero, présentation, CTA, prochains événements, dernier sermon, actualités, infos pratiques.
+- Pages : À propos, Ministères, Événements (liste + détail), Sermons (liste + détail), Galerie, Actualités, Contact, Don.
+- Design responsive, accessible et SEO-friendly (React Helmet Async).
 
-## Structure du Projet
+### Admin (protégé)
+- Authentification JWT.
+- Dashboard.
+- CRUD complet : événements, sermons, annonces, ministères, équipe, galerie.
+- Publication/dépublication.
+- Upload d’images via endpoint `/api/uploads` (stockage local).
 
+### Backend
+- Express + MongoDB + Mongoose.
+- Validation des données avec Zod.
+- Gestion d’erreurs centralisée.
+- CORS configuré.
+- Rate limiting pour l’auth.
+- Sécurité de base (Helmet).
+- Documentation API Swagger.
+- Tests API (Jest + Supertest) : auth + CRUD événements.
+
+## 🧱 Structure
 ```
-church-website/
-│
-├── index.html          # Page principale
-├── css/
-│   └── style.css      # Styles CSS
-├── js/
-│   └── main.js        # JavaScript
-└── images/            # Dossier pour les images
+backend/
+  src/
+    config/
+    controllers/
+    middlewares/
+    models/
+    routes/
+    utils/
+    validators/
+frontend/
+  src/
+    api/
+    components/
+    hooks/
+    pages/
+    routes/
+    styles/
 ```
 
-## Installation
+## ✅ Prérequis
+- Node.js 18+ (ou 20+ recommandé)
+- MongoDB local ou via Docker
 
-1. Clonez ce dépôt ou téléchargez les fichiers
-2. Placez vos images dans le dossier `images/`
-3. Ouvrez `index.html` dans votre navigateur
+## 🚀 Installation
 
-## Personnalisation
+### 1) Cloner et installer
+```bash
+npm install
+npm --prefix backend install
+npm --prefix frontend install
+```
 
-### Images
-- Remplacez `church.jpg` dans le dossier `images/` par votre propre image d'arrière-plan
-- Ajoutez vos propres images pour les sections "À propos" et autres
+### 2) Configurer les environnements
+Créer les fichiers `.env` à partir des exemples :
 
-### Contenu
-- Modifiez le texte dans `index.html` pour l'adapter à votre église
-- Ajustez les liens des réseaux sociaux dans le footer
-- Personnalisez les sections services et événements selon vos besoins
+```bash
+cp backend/.env.example backend/.env
+cp frontend/.env.example frontend/.env
+```
 
-### Style
-- Les couleurs peuvent être modifiées dans les variables CSS au début du fichier `style.css`
-- Ajustez les styles selon vos préférences
+#### Exemple `.env` backend
+```
+PORT=5000
+MONGODB_URI=mongodb://localhost:27017/tfmi
+JWT_SECRET=change_me
+CORS_ORIGIN=http://localhost:5173
+UPLOAD_DIR=uploads
+```
 
-## Compatibilité
+#### Exemple `.env` frontend
+```
+VITE_API_URL=http://localhost:5000
+```
 
-Le site est compatible avec les navigateurs modernes :
-- Chrome
-- Firefox
-- Safari
-- Edge
+### 3) Lancer en développement
+```bash
+npm run dev
+```
 
-## Licence
+Ou séparément :
+```bash
+npm --prefix backend run dev
+npm --prefix frontend run dev
+```
 
-Ce projet est sous licence MIT. Vous êtes libre de l'utiliser et de le modifier comme bon vous semble.
+## 🧪 Tests
+```bash
+npm --prefix backend test
+```
 
-## Support
+## 🌱 Seed (données de démonstration)
+```bash
+npm --prefix backend run seed
+```
 
-Pour toute question ou suggestion, n'hésitez pas à ouvrir une issue sur GitHub. 
+**Admin par défaut**
+- Email: `admin@tfmi.org`
+- Mot de passe: `admin123`
+
+> ⚠️ Pensez à changer ce mot de passe en production.
+
+## 📚 Documentation API
+Swagger est disponible sur :
+```
+http://localhost:5000/api/docs
+```
+
+## 📦 Production
+Frontend :
+```bash
+npm --prefix frontend run build
+```
+
+Backend :
+```bash
+npm --prefix backend run start
+```
+
+## 🐳 Docker (optionnel)
+Un `docker-compose.yml` est fourni pour lancer MongoDB + backend.
+
+```bash
+docker compose up --build
+```
+
+## 🔐 Sécurité & bonnes pratiques
+- Authentification JWT.
+- Rate limiting sur la route login.
+- Validation Zod sur toutes les routes sensibles.
+- Headers sécurisés via Helmet.
+- CORS configurable.
+
+## 📝 Notes
+- Les visuels par défaut sont des SVG dans `/frontend/public/assets` pour éviter les fichiers binaires.
+- Le lien de don externe peut être configuré dans la page Don.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,5 @@
+PORT=5000
+MONGODB_URI=mongodb://localhost:27017/tfmi
+JWT_SECRET=replace_with_strong_secret
+CORS_ORIGIN=http://localhost:5173
+UPLOAD_DIR=uploads

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install
+COPY src ./src
+COPY uploads ./uploads
+EXPOSE 5000
+CMD ["npm", "run", "start"]

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,5 @@
+export default {
+  testEnvironment: 'node',
+  transform: {},
+  testTimeout: 20000
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "tfmi-backend",
+  "version": "1.0.0",
+  "description": "Backend API for Triumphant Faith Ministries",
+  "main": "src/server.js",
+  "type": "module",
+  "scripts": {
+    "dev": "node --watch src/server.js",
+    "start": "node src/server.js",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "seed": "node src/utils/seed.js"
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "express-rate-limit": "^7.2.0",
+    "helmet": "^7.1.0",
+    "jsonwebtoken": "^9.0.2",
+    "mongoose": "^8.5.2",
+    "morgan": "^1.10.0",
+    "multer": "^1.4.5-lts.1",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "mongodb-memory-server": "^9.2.0",
+    "supertest": "^6.3.4"
+  }
+}

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,0 +1,53 @@
+import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import morgan from 'morgan';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import authRoutes from './routes/auth.js';
+import eventRoutes from './routes/events.js';
+import sermonRoutes from './routes/sermons.js';
+import postRoutes from './routes/posts.js';
+import ministryRoutes from './routes/ministries.js';
+import teamRoutes from './routes/team.js';
+import galleryRoutes from './routes/gallery.js';
+import contactRoutes from './routes/contact.js';
+import uploadRoutes from './routes/uploads.js';
+import { errorHandler, notFoundHandler } from './middlewares/errorHandler.js';
+import { swaggerSpec } from './config/swagger.js';
+import swaggerUi from 'swagger-ui-express';
+
+const app = express();
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+app.use(helmet());
+app.use(
+  cors({
+    origin: process.env.CORS_ORIGIN?.split(',') || '*',
+    credentials: true
+  })
+);
+app.use(express.json({ limit: '2mb' }));
+app.use(morgan('dev'));
+
+const uploadsPath = path.join(__dirname, '..', process.env.UPLOAD_DIR || 'uploads');
+app.use(`/${process.env.UPLOAD_DIR || 'uploads'}`, express.static(uploadsPath));
+
+app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+
+app.use('/api/auth', authRoutes);
+app.use('/api/events', eventRoutes);
+app.use('/api/sermons', sermonRoutes);
+app.use('/api/posts', postRoutes);
+app.use('/api/ministries', ministryRoutes);
+app.use('/api/team', teamRoutes);
+app.use('/api/gallery', galleryRoutes);
+app.use('/api/contact', contactRoutes);
+app.use('/api/uploads', uploadRoutes);
+
+app.use(notFoundHandler);
+app.use(errorHandler);
+
+export default app;

--- a/backend/src/config/db.js
+++ b/backend/src/config/db.js
@@ -1,0 +1,6 @@
+import mongoose from 'mongoose';
+
+export const connectDatabase = async (mongoUri) => {
+  mongoose.set('strictQuery', true);
+  await mongoose.connect(mongoUri);
+};

--- a/backend/src/config/swagger.js
+++ b/backend/src/config/swagger.js
@@ -1,0 +1,19 @@
+import swaggerJSDoc from 'swagger-jsdoc';
+
+export const swaggerSpec = swaggerJSDoc({
+  definition: {
+    openapi: '3.0.0',
+    info: {
+      title: 'TFMI API',
+      version: '1.0.0',
+      description: 'API documentation for Triumphant Faith Ministries'
+    },
+    servers: [
+      {
+        url: 'http://localhost:5000',
+        description: 'Local server'
+      }
+    ]
+  },
+  apis: ['./src/routes/*.js']
+});

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -1,0 +1,32 @@
+import bcrypt from 'bcryptjs';
+import User from '../models/User.js';
+import { createAccessToken } from '../utils/token.js';
+
+export const login = async (req, res, next) => {
+  try {
+    const { email, password } = req.body;
+    const user = await User.findOne({ email });
+
+    if (!user) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+
+    const matches = await bcrypt.compare(password, user.passwordHash);
+    if (!matches) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+
+    const token = createAccessToken({ id: user._id, role: user.role });
+
+    return res.json({
+      token,
+      user: {
+        id: user._id,
+        email: user.email,
+        role: user.role
+      }
+    });
+  } catch (error) {
+    return next(error);
+  }
+};

--- a/backend/src/controllers/contactController.js
+++ b/backend/src/controllers/contactController.js
@@ -1,0 +1,6 @@
+export const submitContact = async (req, res) => {
+  return res.status(200).json({
+    message: 'Message reçu. Nous vous contacterons bientôt.',
+    data: req.body
+  });
+};

--- a/backend/src/controllers/eventController.js
+++ b/backend/src/controllers/eventController.js
@@ -1,0 +1,57 @@
+import Event from '../models/Event.js';
+import { listDocuments } from '../utils/listing.js';
+
+export const listEvents = async (req, res, next) => {
+  try {
+    const { page, limit, published } = req.query;
+    const data = await listDocuments({ model: Event, page, limit, published, sort: 'date' });
+    return res.json(data);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const getEvent = async (req, res, next) => {
+  try {
+    const event = await Event.findById(req.params.id);
+    if (!event) {
+      return res.status(404).json({ message: 'Event not found' });
+    }
+    return res.json(event);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const createEvent = async (req, res, next) => {
+  try {
+    const event = await Event.create(req.body);
+    return res.status(201).json(event);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const updateEvent = async (req, res, next) => {
+  try {
+    const event = await Event.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!event) {
+      return res.status(404).json({ message: 'Event not found' });
+    }
+    return res.json(event);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const deleteEvent = async (req, res, next) => {
+  try {
+    const event = await Event.findByIdAndDelete(req.params.id);
+    if (!event) {
+      return res.status(404).json({ message: 'Event not found' });
+    }
+    return res.status(204).send();
+  } catch (error) {
+    return next(error);
+  }
+};

--- a/backend/src/controllers/galleryController.js
+++ b/backend/src/controllers/galleryController.js
@@ -1,0 +1,57 @@
+import GalleryItem from '../models/GalleryItem.js';
+import { listDocuments } from '../utils/listing.js';
+
+export const listGalleryItems = async (req, res, next) => {
+  try {
+    const { page, limit, published } = req.query;
+    const data = await listDocuments({ model: GalleryItem, page, limit, published, sort: '-createdAt' });
+    return res.json(data);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const getGalleryItem = async (req, res, next) => {
+  try {
+    const item = await GalleryItem.findById(req.params.id);
+    if (!item) {
+      return res.status(404).json({ message: 'Gallery item not found' });
+    }
+    return res.json(item);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const createGalleryItem = async (req, res, next) => {
+  try {
+    const item = await GalleryItem.create(req.body);
+    return res.status(201).json(item);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const updateGalleryItem = async (req, res, next) => {
+  try {
+    const item = await GalleryItem.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!item) {
+      return res.status(404).json({ message: 'Gallery item not found' });
+    }
+    return res.json(item);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const deleteGalleryItem = async (req, res, next) => {
+  try {
+    const item = await GalleryItem.findByIdAndDelete(req.params.id);
+    if (!item) {
+      return res.status(404).json({ message: 'Gallery item not found' });
+    }
+    return res.status(204).send();
+  } catch (error) {
+    return next(error);
+  }
+};

--- a/backend/src/controllers/ministryController.js
+++ b/backend/src/controllers/ministryController.js
@@ -1,0 +1,57 @@
+import Ministry from '../models/Ministry.js';
+import { listDocuments } from '../utils/listing.js';
+
+export const listMinistries = async (req, res, next) => {
+  try {
+    const { page, limit, published } = req.query;
+    const data = await listDocuments({ model: Ministry, page, limit, published, sort: 'name' });
+    return res.json(data);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const getMinistry = async (req, res, next) => {
+  try {
+    const ministry = await Ministry.findById(req.params.id);
+    if (!ministry) {
+      return res.status(404).json({ message: 'Ministry not found' });
+    }
+    return res.json(ministry);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const createMinistry = async (req, res, next) => {
+  try {
+    const ministry = await Ministry.create(req.body);
+    return res.status(201).json(ministry);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const updateMinistry = async (req, res, next) => {
+  try {
+    const ministry = await Ministry.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!ministry) {
+      return res.status(404).json({ message: 'Ministry not found' });
+    }
+    return res.json(ministry);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const deleteMinistry = async (req, res, next) => {
+  try {
+    const ministry = await Ministry.findByIdAndDelete(req.params.id);
+    if (!ministry) {
+      return res.status(404).json({ message: 'Ministry not found' });
+    }
+    return res.status(204).send();
+  } catch (error) {
+    return next(error);
+  }
+};

--- a/backend/src/controllers/postController.js
+++ b/backend/src/controllers/postController.js
@@ -1,0 +1,57 @@
+import Post from '../models/Post.js';
+import { listDocuments } from '../utils/listing.js';
+
+export const listPosts = async (req, res, next) => {
+  try {
+    const { page, limit, published } = req.query;
+    const data = await listDocuments({ model: Post, page, limit, published, sort: '-createdAt' });
+    return res.json(data);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const getPost = async (req, res, next) => {
+  try {
+    const post = await Post.findById(req.params.id);
+    if (!post) {
+      return res.status(404).json({ message: 'Post not found' });
+    }
+    return res.json(post);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const createPost = async (req, res, next) => {
+  try {
+    const post = await Post.create(req.body);
+    return res.status(201).json(post);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const updatePost = async (req, res, next) => {
+  try {
+    const post = await Post.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!post) {
+      return res.status(404).json({ message: 'Post not found' });
+    }
+    return res.json(post);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const deletePost = async (req, res, next) => {
+  try {
+    const post = await Post.findByIdAndDelete(req.params.id);
+    if (!post) {
+      return res.status(404).json({ message: 'Post not found' });
+    }
+    return res.status(204).send();
+  } catch (error) {
+    return next(error);
+  }
+};

--- a/backend/src/controllers/sermonController.js
+++ b/backend/src/controllers/sermonController.js
@@ -1,0 +1,57 @@
+import Sermon from '../models/Sermon.js';
+import { listDocuments } from '../utils/listing.js';
+
+export const listSermons = async (req, res, next) => {
+  try {
+    const { page, limit, published } = req.query;
+    const data = await listDocuments({ model: Sermon, page, limit, published, sort: '-date' });
+    return res.json(data);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const getSermon = async (req, res, next) => {
+  try {
+    const sermon = await Sermon.findById(req.params.id);
+    if (!sermon) {
+      return res.status(404).json({ message: 'Sermon not found' });
+    }
+    return res.json(sermon);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const createSermon = async (req, res, next) => {
+  try {
+    const sermon = await Sermon.create(req.body);
+    return res.status(201).json(sermon);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const updateSermon = async (req, res, next) => {
+  try {
+    const sermon = await Sermon.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!sermon) {
+      return res.status(404).json({ message: 'Sermon not found' });
+    }
+    return res.json(sermon);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const deleteSermon = async (req, res, next) => {
+  try {
+    const sermon = await Sermon.findByIdAndDelete(req.params.id);
+    if (!sermon) {
+      return res.status(404).json({ message: 'Sermon not found' });
+    }
+    return res.status(204).send();
+  } catch (error) {
+    return next(error);
+  }
+};

--- a/backend/src/controllers/teamMemberController.js
+++ b/backend/src/controllers/teamMemberController.js
@@ -1,0 +1,57 @@
+import TeamMember from '../models/TeamMember.js';
+import { listDocuments } from '../utils/listing.js';
+
+export const listTeamMembers = async (req, res, next) => {
+  try {
+    const { page, limit, published } = req.query;
+    const data = await listDocuments({ model: TeamMember, page, limit, published, sort: 'order' });
+    return res.json(data);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const getTeamMember = async (req, res, next) => {
+  try {
+    const member = await TeamMember.findById(req.params.id);
+    if (!member) {
+      return res.status(404).json({ message: 'Team member not found' });
+    }
+    return res.json(member);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const createTeamMember = async (req, res, next) => {
+  try {
+    const member = await TeamMember.create(req.body);
+    return res.status(201).json(member);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const updateTeamMember = async (req, res, next) => {
+  try {
+    const member = await TeamMember.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!member) {
+      return res.status(404).json({ message: 'Team member not found' });
+    }
+    return res.json(member);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const deleteTeamMember = async (req, res, next) => {
+  try {
+    const member = await TeamMember.findByIdAndDelete(req.params.id);
+    if (!member) {
+      return res.status(404).json({ message: 'Team member not found' });
+    }
+    return res.status(204).send();
+  } catch (error) {
+    return next(error);
+  }
+};

--- a/backend/src/middlewares/auth.js
+++ b/backend/src/middlewares/auth.js
@@ -1,0 +1,18 @@
+import jwt from 'jsonwebtoken';
+
+export const requireAuth = (req, res, next) => {
+  const authHeader = req.headers.authorization || '';
+  const [, token] = authHeader.split(' ');
+
+  if (!token) {
+    return res.status(401).json({ message: 'Missing token' });
+  }
+
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = payload;
+    return next();
+  } catch (error) {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+};

--- a/backend/src/middlewares/errorHandler.js
+++ b/backend/src/middlewares/errorHandler.js
@@ -1,0 +1,9 @@
+export const notFoundHandler = (req, res, next) => {
+  res.status(404).json({ message: 'Route not found' });
+};
+
+export const errorHandler = (err, req, res, next) => {
+  const status = err.status || 500;
+  const message = err.message || 'Internal server error';
+  res.status(status).json({ message });
+};

--- a/backend/src/middlewares/rateLimit.js
+++ b/backend/src/middlewares/rateLimit.js
@@ -1,0 +1,7 @@
+import rateLimit from 'express-rate-limit';
+
+export const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 10,
+  message: { message: 'Too many login attempts, please try again later.' }
+});

--- a/backend/src/middlewares/validate.js
+++ b/backend/src/middlewares/validate.js
@@ -1,0 +1,14 @@
+export const validateRequest = (schema, location = 'body') => (req, res, next) => {
+  const data = req[location];
+  const result = schema.safeParse(data);
+
+  if (!result.success) {
+    return res.status(400).json({
+      message: 'Validation error',
+      errors: result.error.flatten().fieldErrors
+    });
+  }
+
+  req[location] = result.data;
+  return next();
+};

--- a/backend/src/models/Event.js
+++ b/backend/src/models/Event.js
@@ -1,0 +1,15 @@
+import mongoose from 'mongoose';
+
+const eventSchema = new mongoose.Schema(
+  {
+    title: { type: String, required: true, index: true },
+    description: { type: String, required: true },
+    date: { type: Date, required: true, index: true },
+    location: { type: String, required: true },
+    image: { type: String },
+    published: { type: Boolean, default: false, index: true }
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model('Event', eventSchema);

--- a/backend/src/models/GalleryItem.js
+++ b/backend/src/models/GalleryItem.js
@@ -1,0 +1,12 @@
+import mongoose from 'mongoose';
+
+const galleryItemSchema = new mongoose.Schema(
+  {
+    title: { type: String, required: true },
+    imageUrl: { type: String, required: true },
+    published: { type: Boolean, default: false, index: true }
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model('GalleryItem', galleryItemSchema);

--- a/backend/src/models/Ministry.js
+++ b/backend/src/models/Ministry.js
@@ -1,0 +1,15 @@
+import mongoose from 'mongoose';
+
+const ministrySchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true, index: true },
+    description: { type: String, required: true },
+    leader: { type: String, required: true },
+    schedule: { type: String },
+    image: { type: String },
+    published: { type: Boolean, default: false, index: true }
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model('Ministry', ministrySchema);

--- a/backend/src/models/Post.js
+++ b/backend/src/models/Post.js
@@ -1,0 +1,14 @@
+import mongoose from 'mongoose';
+
+const postSchema = new mongoose.Schema(
+  {
+    title: { type: String, required: true, index: true },
+    content: { type: String, required: true },
+    coverImage: { type: String },
+    tags: [{ type: String }],
+    published: { type: Boolean, default: false, index: true }
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model('Post', postSchema);

--- a/backend/src/models/Sermon.js
+++ b/backend/src/models/Sermon.js
@@ -1,0 +1,16 @@
+import mongoose from 'mongoose';
+
+const sermonSchema = new mongoose.Schema(
+  {
+    title: { type: String, required: true, index: true },
+    preacher: { type: String, required: true },
+    date: { type: Date, required: true, index: true },
+    description: { type: String, required: true },
+    mediaUrl: { type: String },
+    notes: { type: String },
+    published: { type: Boolean, default: false, index: true }
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model('Sermon', sermonSchema);

--- a/backend/src/models/TeamMember.js
+++ b/backend/src/models/TeamMember.js
@@ -1,0 +1,17 @@
+import mongoose from 'mongoose';
+
+const teamMemberSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true },
+    roleTitle: { type: String, required: true },
+    bio: { type: String },
+    photo: { type: String },
+    order: { type: Number, default: 0 },
+    published: { type: Boolean, default: false, index: true }
+  },
+  { timestamps: true }
+);
+
+teamMemberSchema.index({ order: 1 });
+
+export default mongoose.model('TeamMember', teamMemberSchema);

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -1,0 +1,25 @@
+import mongoose from 'mongoose';
+
+const userSchema = new mongoose.Schema(
+  {
+    email: {
+      type: String,
+      required: true,
+      unique: true,
+      lowercase: true,
+      index: true
+    },
+    passwordHash: {
+      type: String,
+      required: true
+    },
+    role: {
+      type: String,
+      enum: ['admin'],
+      default: 'admin'
+    }
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model('User', userSchema);

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,0 +1,32 @@
+import { Router } from 'express';
+import { login } from '../controllers/authController.js';
+import { validateRequest } from '../middlewares/validate.js';
+import { loginSchema } from '../validators/auth.js';
+import { authLimiter } from '../middlewares/rateLimit.js';
+
+const router = Router();
+
+/**
+ * @openapi
+ * /api/auth/login:
+ *   post:
+ *     summary: Admin login
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               email:
+ *                 type: string
+ *               password:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Logged in
+ */
+router.post('/login', authLimiter, validateRequest(loginSchema), login);
+
+export default router;

--- a/backend/src/routes/contact.js
+++ b/backend/src/routes/contact.js
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+import { submitContact } from '../controllers/contactController.js';
+import { validateRequest } from '../middlewares/validate.js';
+import { contactSchema } from '../validators/contact.js';
+
+const router = Router();
+
+/**
+ * @openapi
+ * /api/contact:
+ *   post:
+ *     summary: Submit contact form
+ *     tags: [Contact]
+ */
+router.post('/', validateRequest(contactSchema), submitContact);
+
+export default router;

--- a/backend/src/routes/events.js
+++ b/backend/src/routes/events.js
@@ -1,0 +1,29 @@
+import { Router } from 'express';
+import {
+  listEvents,
+  getEvent,
+  createEvent,
+  updateEvent,
+  deleteEvent
+} from '../controllers/eventController.js';
+import { requireAuth } from '../middlewares/auth.js';
+import { validateRequest } from '../middlewares/validate.js';
+import { eventSchema } from '../validators/event.js';
+import { paginationSchema, idSchema } from '../validators/common.js';
+
+const router = Router();
+
+/**
+ * @openapi
+ * /api/events:
+ *   get:
+ *     summary: List events
+ *     tags: [Events]
+ */
+router.get('/', validateRequest(paginationSchema, 'query'), listEvents);
+router.get('/:id', validateRequest(idSchema, 'params'), getEvent);
+router.post('/', requireAuth, validateRequest(eventSchema), createEvent);
+router.put('/:id', requireAuth, validateRequest(idSchema, 'params'), validateRequest(eventSchema), updateEvent);
+router.delete('/:id', requireAuth, validateRequest(idSchema, 'params'), deleteEvent);
+
+export default router;

--- a/backend/src/routes/gallery.js
+++ b/backend/src/routes/gallery.js
@@ -1,0 +1,29 @@
+import { Router } from 'express';
+import {
+  listGalleryItems,
+  getGalleryItem,
+  createGalleryItem,
+  updateGalleryItem,
+  deleteGalleryItem
+} from '../controllers/galleryController.js';
+import { requireAuth } from '../middlewares/auth.js';
+import { validateRequest } from '../middlewares/validate.js';
+import { gallerySchema } from '../validators/gallery.js';
+import { paginationSchema, idSchema } from '../validators/common.js';
+
+const router = Router();
+
+/**
+ * @openapi
+ * /api/gallery:
+ *   get:
+ *     summary: List gallery items
+ *     tags: [Gallery]
+ */
+router.get('/', validateRequest(paginationSchema, 'query'), listGalleryItems);
+router.get('/:id', validateRequest(idSchema, 'params'), getGalleryItem);
+router.post('/', requireAuth, validateRequest(gallerySchema), createGalleryItem);
+router.put('/:id', requireAuth, validateRequest(idSchema, 'params'), validateRequest(gallerySchema), updateGalleryItem);
+router.delete('/:id', requireAuth, validateRequest(idSchema, 'params'), deleteGalleryItem);
+
+export default router;

--- a/backend/src/routes/ministries.js
+++ b/backend/src/routes/ministries.js
@@ -1,0 +1,29 @@
+import { Router } from 'express';
+import {
+  listMinistries,
+  getMinistry,
+  createMinistry,
+  updateMinistry,
+  deleteMinistry
+} from '../controllers/ministryController.js';
+import { requireAuth } from '../middlewares/auth.js';
+import { validateRequest } from '../middlewares/validate.js';
+import { ministrySchema } from '../validators/ministry.js';
+import { paginationSchema, idSchema } from '../validators/common.js';
+
+const router = Router();
+
+/**
+ * @openapi
+ * /api/ministries:
+ *   get:
+ *     summary: List ministries
+ *     tags: [Ministries]
+ */
+router.get('/', validateRequest(paginationSchema, 'query'), listMinistries);
+router.get('/:id', validateRequest(idSchema, 'params'), getMinistry);
+router.post('/', requireAuth, validateRequest(ministrySchema), createMinistry);
+router.put('/:id', requireAuth, validateRequest(idSchema, 'params'), validateRequest(ministrySchema), updateMinistry);
+router.delete('/:id', requireAuth, validateRequest(idSchema, 'params'), deleteMinistry);
+
+export default router;

--- a/backend/src/routes/posts.js
+++ b/backend/src/routes/posts.js
@@ -1,0 +1,29 @@
+import { Router } from 'express';
+import {
+  listPosts,
+  getPost,
+  createPost,
+  updatePost,
+  deletePost
+} from '../controllers/postController.js';
+import { requireAuth } from '../middlewares/auth.js';
+import { validateRequest } from '../middlewares/validate.js';
+import { postSchema } from '../validators/post.js';
+import { paginationSchema, idSchema } from '../validators/common.js';
+
+const router = Router();
+
+/**
+ * @openapi
+ * /api/posts:
+ *   get:
+ *     summary: List posts
+ *     tags: [Posts]
+ */
+router.get('/', validateRequest(paginationSchema, 'query'), listPosts);
+router.get('/:id', validateRequest(idSchema, 'params'), getPost);
+router.post('/', requireAuth, validateRequest(postSchema), createPost);
+router.put('/:id', requireAuth, validateRequest(idSchema, 'params'), validateRequest(postSchema), updatePost);
+router.delete('/:id', requireAuth, validateRequest(idSchema, 'params'), deletePost);
+
+export default router;

--- a/backend/src/routes/sermons.js
+++ b/backend/src/routes/sermons.js
@@ -1,0 +1,29 @@
+import { Router } from 'express';
+import {
+  listSermons,
+  getSermon,
+  createSermon,
+  updateSermon,
+  deleteSermon
+} from '../controllers/sermonController.js';
+import { requireAuth } from '../middlewares/auth.js';
+import { validateRequest } from '../middlewares/validate.js';
+import { sermonSchema } from '../validators/sermon.js';
+import { paginationSchema, idSchema } from '../validators/common.js';
+
+const router = Router();
+
+/**
+ * @openapi
+ * /api/sermons:
+ *   get:
+ *     summary: List sermons
+ *     tags: [Sermons]
+ */
+router.get('/', validateRequest(paginationSchema, 'query'), listSermons);
+router.get('/:id', validateRequest(idSchema, 'params'), getSermon);
+router.post('/', requireAuth, validateRequest(sermonSchema), createSermon);
+router.put('/:id', requireAuth, validateRequest(idSchema, 'params'), validateRequest(sermonSchema), updateSermon);
+router.delete('/:id', requireAuth, validateRequest(idSchema, 'params'), deleteSermon);
+
+export default router;

--- a/backend/src/routes/team.js
+++ b/backend/src/routes/team.js
@@ -1,0 +1,29 @@
+import { Router } from 'express';
+import {
+  listTeamMembers,
+  getTeamMember,
+  createTeamMember,
+  updateTeamMember,
+  deleteTeamMember
+} from '../controllers/teamMemberController.js';
+import { requireAuth } from '../middlewares/auth.js';
+import { validateRequest } from '../middlewares/validate.js';
+import { teamMemberSchema } from '../validators/teamMember.js';
+import { paginationSchema, idSchema } from '../validators/common.js';
+
+const router = Router();
+
+/**
+ * @openapi
+ * /api/team:
+ *   get:
+ *     summary: List team members
+ *     tags: [Team]
+ */
+router.get('/', validateRequest(paginationSchema, 'query'), listTeamMembers);
+router.get('/:id', validateRequest(idSchema, 'params'), getTeamMember);
+router.post('/', requireAuth, validateRequest(teamMemberSchema), createTeamMember);
+router.put('/:id', requireAuth, validateRequest(idSchema, 'params'), validateRequest(teamMemberSchema), updateTeamMember);
+router.delete('/:id', requireAuth, validateRequest(idSchema, 'params'), deleteTeamMember);
+
+export default router;

--- a/backend/src/routes/uploads.js
+++ b/backend/src/routes/uploads.js
@@ -1,0 +1,37 @@
+import { Router } from 'express';
+import multer from 'multer';
+import path from 'path';
+import fs from 'fs';
+import { requireAuth } from '../middlewares/auth.js';
+
+const router = Router();
+
+const uploadDir = process.env.UPLOAD_DIR || 'uploads';
+
+if (!fs.existsSync(uploadDir)) {
+  fs.mkdirSync(uploadDir, { recursive: true });
+}
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => {
+    cb(null, uploadDir);
+  },
+  filename: (req, file, cb) => {
+    const timestamp = Date.now();
+    const ext = path.extname(file.originalname);
+    cb(null, `${timestamp}${ext}`);
+  }
+});
+
+const upload = multer({ storage });
+
+router.post('/', requireAuth, upload.single('file'), (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ message: 'No file uploaded' });
+  }
+  return res.status(201).json({
+    url: `/${uploadDir}/${req.file.filename}`
+  });
+});
+
+export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,0 +1,21 @@
+import dotenv from 'dotenv';
+import app from './app.js';
+import { connectDatabase } from './config/db.js';
+
+dotenv.config();
+
+const PORT = process.env.PORT || 5000;
+
+const startServer = async () => {
+  try {
+    await connectDatabase(process.env.MONGODB_URI);
+    app.listen(PORT, () => {
+      console.log(`Server running on port ${PORT}`);
+    });
+  } catch (error) {
+    console.error('Failed to start server', error);
+    process.exit(1);
+  }
+};
+
+startServer();

--- a/backend/src/utils/listing.js
+++ b/backend/src/utils/listing.js
@@ -1,0 +1,24 @@
+import { buildPagination } from './pagination.js';
+
+export const listDocuments = async ({ model, page, limit, published, sort = '-createdAt' }) => {
+  const query = {};
+  if (typeof published === 'boolean') {
+    query.published = published;
+  }
+  const { skip } = buildPagination({ page, limit });
+
+  const [items, total] = await Promise.all([
+    model.find(query).sort(sort).skip(skip).limit(limit),
+    model.countDocuments(query)
+  ]);
+
+  return {
+    items,
+    pagination: {
+      page,
+      limit,
+      total,
+      totalPages: Math.ceil(total / limit)
+    }
+  };
+};

--- a/backend/src/utils/pagination.js
+++ b/backend/src/utils/pagination.js
@@ -1,0 +1,4 @@
+export const buildPagination = ({ page, limit }) => {
+  const skip = (page - 1) * limit;
+  return { skip, limit };
+};

--- a/backend/src/utils/seed.js
+++ b/backend/src/utils/seed.js
@@ -1,0 +1,141 @@
+import dotenv from 'dotenv';
+import bcrypt from 'bcryptjs';
+import { connectDatabase } from '../config/db.js';
+import User from '../models/User.js';
+import Event from '../models/Event.js';
+import Sermon from '../models/Sermon.js';
+import Post from '../models/Post.js';
+import Ministry from '../models/Ministry.js';
+import TeamMember from '../models/TeamMember.js';
+import GalleryItem from '../models/GalleryItem.js';
+
+dotenv.config();
+
+const seed = async () => {
+  await connectDatabase(process.env.MONGODB_URI);
+
+  await Promise.all([
+    User.deleteMany({}),
+    Event.deleteMany({}),
+    Sermon.deleteMany({}),
+    Post.deleteMany({}),
+    Ministry.deleteMany({}),
+    TeamMember.deleteMany({}),
+    GalleryItem.deleteMany({})
+  ]);
+
+  const passwordHash = await bcrypt.hash('admin123', 10);
+  await User.create({
+    email: 'admin@tfmi.org',
+    passwordHash,
+    role: 'admin'
+  });
+
+  await Event.create([
+    {
+      title: 'Culte Dominical de Louange',
+      description: "Un temps de célébration et d'enseignement pour toute la communauté.",
+      date: new Date('2024-08-04T09:00:00Z'),
+      location: 'TFMI Mbog Abang, Yaoundé',
+      image: '/assets/community.svg',
+      published: true
+    },
+    {
+      title: 'Veillée de Prière',
+      description: 'Soirée de prière et intercession pour les familles.',
+      date: new Date('2024-08-09T18:00:00Z'),
+      location: 'TFMI Santa Barbara',
+      image: '/assets/hero.svg',
+      published: true
+    }
+  ]);
+
+  await Sermon.create([
+    {
+      title: 'Ensemble vers la victoire en Christ',
+      preacher: 'Apôtre Julius EKIE',
+      date: new Date('2024-07-21T09:00:00Z'),
+      description: 'Un message de foi sur le triomphe en Christ.',
+      mediaUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      notes: 'Colossiens 2:15, Romains 8:37',
+      published: true
+    }
+  ]);
+
+  await Post.create([
+    {
+      title: 'Annonce : Programme de Jeûne',
+      content: 'Rejoignez-nous pour 7 jours de consécration et de prière.',
+      coverImage: '/assets/prayer.svg',
+      tags: ['prière', 'annonces'],
+      published: true
+    }
+  ]);
+
+  await Ministry.create([
+    {
+      name: "Culte d'Adoration",
+      description: 'Louer Dieu avec passion et excellence.',
+      leader: 'Pasteur Marie',
+      schedule: 'Dimanche 09:00 - 12:00',
+      image: '/assets/ministry.svg',
+      published: true
+    },
+    {
+      name: 'École Biblique',
+      description: 'Formation spirituelle et discipulat.',
+      leader: 'Pasteur Pierre',
+      schedule: 'Jeudi 18:30 - 20:30',
+      image: '/assets/ministry.svg',
+      published: true
+    }
+  ]);
+
+  await TeamMember.create([
+    {
+      name: 'Apôtre Julius EKIE',
+      roleTitle: 'Fondateur',
+      bio: "Fondateur et visionnaire de TFMI.",
+      photo: '/assets/pastor-apostle.svg',
+      order: 1,
+      published: true
+    },
+    {
+      name: 'Pasteur Pierre',
+      roleTitle: 'Enseignement biblique',
+      bio: "Responsable de l'enseignement biblique.",
+      photo: '/assets/pastor-apostle.svg',
+      order: 2,
+      published: true
+    },
+    {
+      name: 'Pasteur Marie',
+      roleTitle: 'Louange',
+      bio: 'En charge du ministère de la louange.',
+      photo: '/assets/pastor-apostle.svg',
+      order: 3,
+      published: true
+    }
+  ]);
+
+  await GalleryItem.create([
+    {
+      title: 'Communauté en louange',
+      imageUrl: '/assets/community.svg',
+      published: true
+    },
+    {
+      title: 'Moments de prière',
+      imageUrl: '/assets/prayer.svg',
+      published: true
+    }
+  ]);
+
+  console.log('Seed completed');
+  process.exit(0);
+};
+
+seed().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/backend/src/utils/token.js
+++ b/backend/src/utils/token.js
@@ -1,0 +1,4 @@
+import jwt from 'jsonwebtoken';
+
+export const createAccessToken = (payload) =>
+  jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '2h' });

--- a/backend/src/validators/auth.js
+++ b/backend/src/validators/auth.js
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+
+export const loginSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6)
+});

--- a/backend/src/validators/common.js
+++ b/backend/src/validators/common.js
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+export const paginationSchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(50).default(10),
+  published: z.coerce.boolean().optional()
+});
+
+export const idSchema = z.object({
+  id: z.string().min(1)
+});
+
+export const urlOrPath = z
+  .string()
+  .refine((value) => value.startsWith('/') || /^https?:\/\//.test(value), {
+    message: 'Must be a URL or a relative path'
+  });

--- a/backend/src/validators/contact.js
+++ b/backend/src/validators/contact.js
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const contactSchema = z.object({
+  name: z.string().min(2),
+  email: z.string().email(),
+  message: z.string().min(10)
+});

--- a/backend/src/validators/event.js
+++ b/backend/src/validators/event.js
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+import { urlOrPath } from './common.js';
+
+export const eventSchema = z.object({
+  title: z.string().min(2),
+  description: z.string().min(10),
+  date: z.coerce.date(),
+  location: z.string().min(2),
+  image: urlOrPath.optional().or(z.literal('')),
+  published: z.boolean().optional()
+});

--- a/backend/src/validators/gallery.js
+++ b/backend/src/validators/gallery.js
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+import { urlOrPath } from './common.js';
+
+export const gallerySchema = z.object({
+  title: z.string().min(2),
+  imageUrl: urlOrPath,
+  published: z.boolean().optional()
+});

--- a/backend/src/validators/ministry.js
+++ b/backend/src/validators/ministry.js
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+import { urlOrPath } from './common.js';
+
+export const ministrySchema = z.object({
+  name: z.string().min(2),
+  description: z.string().min(10),
+  leader: z.string().min(2),
+  schedule: z.string().optional().or(z.literal('')),
+  image: urlOrPath.optional().or(z.literal('')),
+  published: z.boolean().optional()
+});

--- a/backend/src/validators/post.js
+++ b/backend/src/validators/post.js
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+import { urlOrPath } from './common.js';
+
+export const postSchema = z.object({
+  title: z.string().min(2),
+  content: z.string().min(10),
+  coverImage: urlOrPath.optional().or(z.literal('')),
+  tags: z.array(z.string()).optional(),
+  published: z.boolean().optional()
+});

--- a/backend/src/validators/sermon.js
+++ b/backend/src/validators/sermon.js
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const sermonSchema = z.object({
+  title: z.string().min(2),
+  preacher: z.string().min(2),
+  date: z.coerce.date(),
+  description: z.string().min(10),
+  mediaUrl: z.string().url().optional().or(z.literal('')),
+  notes: z.string().optional().or(z.literal('')),
+  published: z.boolean().optional()
+});

--- a/backend/src/validators/teamMember.js
+++ b/backend/src/validators/teamMember.js
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+import { urlOrPath } from './common.js';
+
+export const teamMemberSchema = z.object({
+  name: z.string().min(2),
+  roleTitle: z.string().min(2),
+  bio: z.string().optional().or(z.literal('')),
+  photo: urlOrPath.optional().or(z.literal('')),
+  order: z.number().int().optional(),
+  published: z.boolean().optional()
+});

--- a/backend/tests/auth.test.js
+++ b/backend/tests/auth.test.js
@@ -1,0 +1,37 @@
+import request from 'supertest';
+import bcrypt from 'bcryptjs';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import app from '../src/app.js';
+import { connectDatabase } from '../src/config/db.js';
+import User from '../src/models/User.js';
+
+let mongoServer;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  process.env.MONGODB_URI = mongoServer.getUri();
+  process.env.JWT_SECRET = 'test-secret';
+  await connectDatabase(process.env.MONGODB_URI);
+
+  const passwordHash = await bcrypt.hash('admin123', 10);
+  await User.create({ email: 'admin@tfmi.org', passwordHash, role: 'admin' });
+});
+
+afterAll(async () => {
+  await mongoose.connection.close();
+  if (mongoServer) {
+    await mongoServer.stop();
+  }
+});
+
+test('logs in admin with valid credentials', async () => {
+  const response = await request(app).post('/api/auth/login').send({
+    email: 'admin@tfmi.org',
+    password: 'admin123'
+  });
+
+  expect(response.status).toBe(200);
+  expect(response.body.token).toBeTruthy();
+  expect(response.body.user.email).toBe('admin@tfmi.org');
+});

--- a/backend/tests/events.test.js
+++ b/backend/tests/events.test.js
@@ -1,0 +1,53 @@
+import request from 'supertest';
+import bcrypt from 'bcryptjs';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import app from '../src/app.js';
+import { connectDatabase } from '../src/config/db.js';
+import User from '../src/models/User.js';
+
+let mongoServer;
+let token;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  process.env.MONGODB_URI = mongoServer.getUri();
+  process.env.JWT_SECRET = 'test-secret';
+  await connectDatabase(process.env.MONGODB_URI);
+
+  const passwordHash = await bcrypt.hash('admin123', 10);
+  await User.create({ email: 'admin@tfmi.org', passwordHash, role: 'admin' });
+
+  const loginRes = await request(app).post('/api/auth/login').send({
+    email: 'admin@tfmi.org',
+    password: 'admin123'
+  });
+  token = loginRes.body.token;
+});
+
+afterAll(async () => {
+  await mongoose.connection.close();
+  if (mongoServer) {
+    await mongoServer.stop();
+  }
+});
+
+test('creates and lists events', async () => {
+  const createRes = await request(app)
+    .post('/api/events')
+    .set('Authorization', `Bearer ${token}`)
+    .send({
+      title: 'Culte dominical',
+      description: 'Célébration de louange et adoration.',
+      date: '2024-08-04T09:00:00Z',
+      location: 'TFMI Mbog Abang',
+      image: 'https://example.com/image.jpg',
+      published: true
+    });
+
+  expect(createRes.status).toBe(201);
+
+  const listRes = await request(app).get('/api/events');
+  expect(listRes.status).toBe(200);
+  expect(listRes.body.items.length).toBe(1);
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.9'
+services:
+  mongo:
+    image: mongo:7
+    restart: unless-stopped
+    ports:
+      - '27017:27017'
+    volumes:
+      - mongo_data:/data/db
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    ports:
+      - '5000:5000'
+    env_file:
+      - ./backend/.env
+    depends_on:
+      - mongo
+volumes:
+  mongo_data:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:5000

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TFMI - Triumphant Faith Ministries</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body class="bg-slate-950 text-slate-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "tfmi-frontend",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.51.1",
+    "axios": "^1.7.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-helmet-async": "^2.0.5",
+    "react-hook-form": "^7.52.1",
+    "react-router-dom": "^6.25.1",
+    "zod": "^3.23.8",
+    "@hookform/resolvers": "^3.9.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.1",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.40",
+    "tailwindcss": "^3.4.7",
+    "vite": "^5.3.5"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/frontend/public/assets/community.svg
+++ b/frontend/public/assets/community.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400" role="img" aria-labelledby="title desc">
+  <title id="title">Communauté TFMI</title>
+  <desc id="desc">Illustration abstraite de la communauté</desc>
+  <rect width="600" height="400" fill="#0f172a"/>
+  <circle cx="120" cy="200" r="60" fill="#1f6b4c"/>
+  <circle cx="300" cy="180" r="80" fill="#f0b429"/>
+  <circle cx="480" cy="210" r="60" fill="#1f6b4c"/>
+  <text x="300" y="360" text-anchor="middle" font-size="28" font-family="Poppins, sans-serif" fill="#f8fafc">Ensemble vers la victoire</text>
+</svg>

--- a/frontend/public/assets/hero.svg
+++ b/frontend/public/assets/hero.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" role="img" aria-labelledby="title desc">
+  <title id="title">Communauté TFMI</title>
+  <desc id="desc">Bannière abstraite avec soleil levant</desc>
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="100%" stop-color="#1f6b4c"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="400" fill="url(#sky)"/>
+  <circle cx="600" cy="120" r="70" fill="#f0b429" opacity="0.8"/>
+  <path d="M0 320 C200 280 400 360 800 300 L800 400 L0 400 Z" fill="#0f172a" opacity="0.9"/>
+  <text x="60" y="90" font-size="32" font-family="Poppins, sans-serif" fill="#f8fafc">Triumphant Faith Ministries</text>
+</svg>

--- a/frontend/public/assets/logo.svg
+++ b/frontend/public/assets/logo.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" role="img" aria-labelledby="title desc">
+  <title id="title">TFMI Logo</title>
+  <desc id="desc">Logo circulaire avec croix centrale pour TFMI</desc>
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f6b4c"/>
+      <stop offset="100%" stop-color="#f0b429"/>
+    </linearGradient>
+  </defs>
+  <circle cx="100" cy="100" r="96" fill="url(#grad)" stroke="#0f172a" stroke-width="4"/>
+  <rect x="92" y="40" width="16" height="120" fill="#0f172a"/>
+  <rect x="60" y="92" width="80" height="16" fill="#0f172a"/>
+  <text x="100" y="180" text-anchor="middle" font-size="20" font-family="Poppins, sans-serif" fill="#0f172a">TFMI</text>
+</svg>

--- a/frontend/public/assets/ministry.svg
+++ b/frontend/public/assets/ministry.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400" role="img" aria-labelledby="title desc">
+  <title id="title">Ministère TFMI</title>
+  <desc id="desc">Illustration abstraite pour ministère</desc>
+  <rect width="600" height="400" fill="#1f2937"/>
+  <path d="M0 320 C150 260 300 360 600 300 L600 400 L0 400 Z" fill="#1f6b4c"/>
+  <circle cx="500" cy="90" r="50" fill="#f0b429"/>
+  <text x="40" y="80" font-size="24" font-family="Poppins, sans-serif" fill="#f8fafc">Service & Louange</text>
+</svg>

--- a/frontend/public/assets/pastor-apostle.svg
+++ b/frontend/public/assets/pastor-apostle.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 300" role="img" aria-labelledby="title desc">
+  <title id="title">Responsable TFMI</title>
+  <desc id="desc">Portrait stylisé pour membre de l'équipe</desc>
+  <rect width="300" height="300" fill="#0f172a"/>
+  <circle cx="150" cy="120" r="60" fill="#1f6b4c"/>
+  <rect x="70" y="190" width="160" height="70" rx="35" fill="#f0b429"/>
+  <text x="150" y="280" text-anchor="middle" font-size="18" font-family="Poppins, sans-serif" fill="#f8fafc">TFMI</text>
+</svg>

--- a/frontend/public/assets/prayer.svg
+++ b/frontend/public/assets/prayer.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400" role="img" aria-labelledby="title desc">
+  <title id="title">Prière TFMI</title>
+  <desc id="desc">Illustration abstraite de prière</desc>
+  <rect width="600" height="400" fill="#0f172a"/>
+  <circle cx="300" cy="170" r="90" fill="#1f6b4c"/>
+  <rect x="260" y="90" width="80" height="160" fill="#f0b429" opacity="0.85"/>
+  <text x="300" y="330" text-anchor="middle" font-size="24" font-family="Poppins, sans-serif" fill="#f8fafc">Temps de prière</text>
+</svg>

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,0 +1,15 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:5000'
+});
+
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('tfmi_token');
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+export default api;

--- a/frontend/src/api/resources.js
+++ b/frontend/src/api/resources.js
@@ -1,0 +1,79 @@
+import api from './client';
+
+export const login = async (payload) => {
+  const { data } = await api.post('/api/auth/login', payload);
+  return data;
+};
+
+export const fetchEvents = async (params) => {
+  const { data } = await api.get('/api/events', { params });
+  return data;
+};
+
+export const fetchEvent = async (id) => {
+  const { data } = await api.get(`/api/events/${id}`);
+  return data;
+};
+
+export const fetchSermons = async (params) => {
+  const { data } = await api.get('/api/sermons', { params });
+  return data;
+};
+
+export const fetchSermon = async (id) => {
+  const { data } = await api.get(`/api/sermons/${id}`);
+  return data;
+};
+
+export const fetchPosts = async (params) => {
+  const { data } = await api.get('/api/posts', { params });
+  return data;
+};
+
+export const fetchPost = async (id) => {
+  const { data } = await api.get(`/api/posts/${id}`);
+  return data;
+};
+
+export const fetchMinistries = async (params) => {
+  const { data } = await api.get('/api/ministries', { params });
+  return data;
+};
+
+export const fetchTeam = async (params) => {
+  const { data } = await api.get('/api/team', { params });
+  return data;
+};
+
+export const fetchGallery = async (params) => {
+  const { data } = await api.get('/api/gallery', { params });
+  return data;
+};
+
+export const submitContact = async (payload) => {
+  const { data } = await api.post('/api/contact', payload);
+  return data;
+};
+
+export const createResource = async (resource, payload) => {
+  const { data } = await api.post(`/api/${resource}`, payload);
+  return data;
+};
+
+export const updateResource = async (resource, id, payload) => {
+  const { data } = await api.put(`/api/${resource}/${id}`, payload);
+  return data;
+};
+
+export const deleteResource = async (resource, id) => {
+  await api.delete(`/api/${resource}/${id}`);
+};
+
+export const uploadFile = async (file) => {
+  const formData = new FormData();
+  formData.append('file', file);
+  const { data } = await api.post('/api/uploads', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' }
+  });
+  return data;
+};

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -1,0 +1,37 @@
+const Footer = () => (
+  <footer className="border-t border-slate-800 bg-slate-950">
+    <div className="mx-auto max-w-6xl px-6 py-10 text-sm text-slate-400">
+      <div className="grid gap-6 md:grid-cols-3">
+        <div>
+          <h3 className="text-lg font-semibold text-white">TFMI</h3>
+          <p>Triumphant Faith Ministries International</p>
+          <p>Ensemble vers la victoire en Christ</p>
+        </div>
+        <div>
+          <h3 className="text-lg font-semibold text-white">Contact</h3>
+          <p>contact@tfmi.org</p>
+          <p>+237 XXX XXX XXX</p>
+        </div>
+        <div>
+          <h3 className="text-lg font-semibold text-white">Suivez-nous</h3>
+          <div className="flex gap-3">
+            <a href="#" className="hover:text-secondary" aria-label="Facebook">
+              Facebook
+            </a>
+            <a href="#" className="hover:text-secondary" aria-label="YouTube">
+              YouTube
+            </a>
+            <a href="#" className="hover:text-secondary" aria-label="Instagram">
+              Instagram
+            </a>
+          </div>
+        </div>
+      </div>
+      <div className="mt-8 border-t border-slate-800 pt-4 text-xs">
+        © 2024 TFMI. Tous droits réservés.
+      </div>
+    </div>
+  </footer>
+);
+
+export default Footer;

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,0 +1,12 @@
+import Navbar from './Navbar';
+import Footer from './Footer';
+
+const Layout = ({ children }) => (
+  <div className="flex min-h-screen flex-col bg-slate-950 text-slate-100">
+    <Navbar />
+    <main className="flex-1">{children}</main>
+    <Footer />
+  </div>
+);
+
+export default Layout;

--- a/frontend/src/components/Meta.jsx
+++ b/frontend/src/components/Meta.jsx
@@ -1,0 +1,10 @@
+import { Helmet } from 'react-helmet-async';
+
+const Meta = ({ title, description }) => (
+  <Helmet>
+    <title>{title}</title>
+    {description && <meta name="description" content={description} />}
+  </Helmet>
+);
+
+export default Meta;

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,0 +1,42 @@
+import { NavLink } from 'react-router-dom';
+
+const navItems = [
+  { to: '/', label: 'Accueil' },
+  { to: '/about', label: 'À propos' },
+  { to: '/ministries', label: 'Ministères' },
+  { to: '/events', label: 'Événements' },
+  { to: '/sermons', label: 'Sermons' },
+  { to: '/gallery', label: 'Galerie' },
+  { to: '/posts', label: 'Actualités' },
+  { to: '/contact', label: 'Contact' },
+  { to: '/don', label: 'Don' }
+];
+
+const Navbar = () => (
+  <header className="sticky top-0 z-40 bg-slate-950/80 backdrop-blur">
+    <nav className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+      <div className="flex items-center gap-3">
+        <img src="/assets/logo.svg" alt="TFMI" className="h-10 w-10 rounded-full" />
+        <div>
+          <p className="text-lg font-semibold">TFMI</p>
+          <p className="text-xs text-slate-400">Triumphant Faith Ministries</p>
+        </div>
+      </div>
+      <div className="hidden flex-wrap items-center gap-4 text-sm font-medium text-slate-200 lg:flex">
+        {navItems.map((item) => (
+          <NavLink
+            key={item.to}
+            to={item.to}
+            className={({ isActive }) =>
+              `transition hover:text-secondary ${isActive ? 'text-secondary' : ''}`
+            }
+          >
+            {item.label}
+          </NavLink>
+        ))}
+      </div>
+    </nav>
+  </header>
+);
+
+export default Navbar;

--- a/frontend/src/components/admin/AdminLayout.jsx
+++ b/frontend/src/components/admin/AdminLayout.jsx
@@ -1,0 +1,37 @@
+import { NavLink, Outlet } from 'react-router-dom';
+
+const AdminLayout = () => (
+  <div className="min-h-screen bg-slate-950 text-slate-100">
+    <div className="mx-auto flex max-w-6xl flex-col gap-6 px-6 py-8">
+      <header className="flex flex-col gap-2 border-b border-slate-800 pb-4">
+        <h1 className="text-2xl font-semibold">Administration TFMI</h1>
+        <nav className="flex flex-wrap gap-4 text-sm">
+          <NavLink to="/admin" end className={({ isActive }) => (isActive ? 'text-secondary' : '')}>
+            Dashboard
+          </NavLink>
+          <NavLink to="/admin/events" className={({ isActive }) => (isActive ? 'text-secondary' : '')}>
+            Événements
+          </NavLink>
+          <NavLink to="/admin/sermons" className={({ isActive }) => (isActive ? 'text-secondary' : '')}>
+            Sermons
+          </NavLink>
+          <NavLink to="/admin/posts" className={({ isActive }) => (isActive ? 'text-secondary' : '')}>
+            Annonces
+          </NavLink>
+          <NavLink to="/admin/ministries" className={({ isActive }) => (isActive ? 'text-secondary' : '')}>
+            Ministères
+          </NavLink>
+          <NavLink to="/admin/team" className={({ isActive }) => (isActive ? 'text-secondary' : '')}>
+            Équipe
+          </NavLink>
+          <NavLink to="/admin/gallery" className={({ isActive }) => (isActive ? 'text-secondary' : '')}>
+            Galerie
+          </NavLink>
+        </nav>
+      </header>
+      <Outlet />
+    </div>
+  </div>
+);
+
+export default AdminLayout;

--- a/frontend/src/components/admin/ResourceManager.jsx
+++ b/frontend/src/components/admin/ResourceManager.jsx
@@ -1,0 +1,196 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  createResource,
+  deleteResource,
+  updateResource,
+  uploadFile
+} from '../../api/resources';
+import api from '../../api/client';
+
+const ResourceManager = ({ resource, title, fields }) => {
+  const queryClient = useQueryClient();
+  const [formState, setFormState] = useState({});
+  const [editingId, setEditingId] = useState(null);
+  const [uploading, setUploading] = useState(false);
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: [resource],
+    queryFn: async () => {
+      const { data: response } = await api.get(`/api/${resource}`, {
+        params: { page: 1, limit: 20 }
+      });
+      return response;
+    }
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (payload) => createResource(resource, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [resource] });
+      setFormState({});
+    }
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, payload }) => updateResource(resource, id, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [resource] });
+      setEditingId(null);
+      setFormState({});
+    }
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id) => deleteResource(resource, id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: [resource] })
+  });
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    const payload = { ...formState };
+    fields.forEach((field) => {
+      if (field.type === 'number' && payload[field.name] !== undefined) {
+        payload[field.name] = Number(payload[field.name]);
+      }
+      if (field.name === 'tags' && typeof payload.tags === 'string') {
+        payload.tags = payload.tags
+          .split(',')
+          .map((tag) => tag.trim())
+          .filter(Boolean);
+      }
+    });
+
+    if (editingId) {
+      updateMutation.mutate({ id: editingId, payload });
+    } else {
+      createMutation.mutate(payload);
+    }
+  };
+
+  const handleUpload = async (event, fieldName) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    setUploading(true);
+    try {
+      const result = await uploadFile(file);
+      setFormState((prev) => ({ ...prev, [fieldName]: result.url }));
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const selectItem = (item) => {
+    setEditingId(item._id);
+    const nextState = fields.reduce((acc, field) => {
+      if (field.name === 'tags' && Array.isArray(item.tags)) {
+        acc[field.name] = item.tags.join(', ');
+      } else if (field.type === 'datetime-local' && item[field.name]) {
+        const date = new Date(item[field.name]);
+        acc[field.name] = date.toISOString().slice(0, 16);
+      } else {
+        acc[field.name] = item[field.name] ?? '';
+      }
+      return acc;
+    }, {});
+    setFormState(nextState);
+  };
+
+  return (
+    <section className="grid gap-8 lg:grid-cols-[1.3fr_1fr]">
+      <div className="space-y-4">
+        <h2 className="text-xl font-semibold">{title}</h2>
+        {isLoading && <p>Chargement...</p>}
+        {error && <p className="text-red-400">Erreur de chargement.</p>}
+        <div className="space-y-4">
+          {data?.items?.map((item) => (
+            <div key={item._id} className="card flex flex-col gap-3">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-lg font-semibold">{item.title || item.name}</p>
+                  {item.date && <p className="text-sm text-slate-400">{new Date(item.date).toLocaleDateString('fr-FR')}</p>}
+                </div>
+                <span className={item.published ? 'text-green-400' : 'text-slate-400'}>
+                  {item.published ? 'Publié' : 'Brouillon'}
+                </span>
+              </div>
+              <p className="text-sm text-slate-400 line-clamp-3">{item.description || item.content || item.bio}</p>
+              <div className="flex gap-3">
+                <button type="button" className="button-outline" onClick={() => selectItem(item)}>
+                  Éditer
+                </button>
+                <button
+                  type="button"
+                  className="button-primary"
+                  onClick={() => deleteMutation.mutate(item._id)}
+                >
+                  Supprimer
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+      <form onSubmit={handleSubmit} className="card space-y-4">
+        <h3 className="text-lg font-semibold">{editingId ? 'Mettre à jour' : 'Créer un élément'}</h3>
+        {fields.map((field) => (
+          <label key={field.name} className="block text-sm">
+            <span className="mb-2 block text-slate-400">{field.label}</span>
+            {field.type === 'textarea' ? (
+              <textarea
+                className="input min-h-[120px]"
+                value={formState[field.name] ?? ''}
+                onChange={(event) =>
+                  setFormState((prev) => ({ ...prev, [field.name]: event.target.value }))
+                }
+              />
+            ) : field.type === 'checkbox' ? (
+              <input
+                type="checkbox"
+                checked={Boolean(formState[field.name])}
+                onChange={(event) =>
+                  setFormState((prev) => ({ ...prev, [field.name]: event.target.checked }))
+                }
+              />
+            ) : field.type === 'file' ? (
+              <input
+                type="file"
+                onChange={(event) => handleUpload(event, field.name)}
+                className="text-sm"
+              />
+            ) : (
+              <input
+                className="input"
+                type={field.type}
+                value={formState[field.name] ?? ''}
+                onChange={(event) =>
+                  setFormState((prev) => ({ ...prev, [field.name]: event.target.value }))
+                }
+              />
+            )}
+          </label>
+        ))}
+        {uploading && <p className="text-sm text-secondary">Téléversement en cours...</p>}
+        <div className="flex gap-3">
+          <button type="submit" className="button-primary">
+            {editingId ? 'Mettre à jour' : 'Créer'}
+          </button>
+          {editingId && (
+            <button
+              type="button"
+              className="button-outline"
+              onClick={() => {
+                setEditingId(null);
+                setFormState({});
+              }}
+            >
+              Annuler
+            </button>
+          )}
+        </div>
+      </form>
+    </section>
+  );
+};
+
+export default ResourceManager;

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+import { login } from '../api/resources';
+
+export const useAuth = () => {
+  const [user, setUser] = useState(() => {
+    const stored = localStorage.getItem('tfmi_user');
+    return stored ? JSON.parse(stored) : null;
+  });
+
+  const signIn = async (payload) => {
+    const data = await login(payload);
+    localStorage.setItem('tfmi_token', data.token);
+    localStorage.setItem('tfmi_user', JSON.stringify(data.user));
+    setUser(data.user);
+    return data.user;
+  };
+
+  const signOut = () => {
+    localStorage.removeItem('tfmi_token');
+    localStorage.removeItem('tfmi_user');
+    setUser(null);
+  };
+
+  return { user, signIn, signOut };
+};

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { HelmetProvider } from 'react-helmet-async';
+import App from './routes/App.jsx';
+import './styles/index.css';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false
+    }
+  }
+});
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <HelmetProvider>
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </QueryClientProvider>
+    </HelmetProvider>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/About.jsx
+++ b/frontend/src/pages/About.jsx
@@ -1,0 +1,70 @@
+import Layout from '../components/Layout';
+import Meta from '../components/Meta';
+
+const About = () => (
+  <Layout>
+    <Meta title="TFMI - À propos" description="Mission, vision et équipe pastorale de TFMI" />
+    <section className="mx-auto max-w-6xl space-y-10 px-6 py-16">
+      <div className="space-y-4">
+        <h1 className="section-title">Mission, Vision et Valeurs</h1>
+        <p className="text-slate-300">
+          Conduire les âmes à Christ et les équiper pour une vie de victoire et de triomphe dans la foi.
+        </p>
+        <p className="text-slate-300">
+          Notre mission est d'annoncer la bonne nouvelle et de former des disciples engagés.
+        </p>
+      </div>
+      <div className="grid gap-6 md:grid-cols-3">
+        <div className="card">
+          <h3 className="text-lg font-semibold">Foi</h3>
+          <p className="text-sm text-slate-400">Fondés sur la Parole de Dieu</p>
+        </div>
+        <div className="card">
+          <h3 className="text-lg font-semibold">Amour</h3>
+          <p className="text-sm text-slate-400">Unis dans l'amour du Christ</p>
+        </div>
+        <div className="card">
+          <h3 className="text-lg font-semibold">Esprit</h3>
+          <p className="text-sm text-slate-400">Guidés par le Saint-Esprit</p>
+        </div>
+      </div>
+    </section>
+
+    <section className="bg-slate-900/60">
+      <div className="mx-auto max-w-6xl px-6 py-16">
+        <h2 className="section-title">Histoire de l'Église</h2>
+        <p className="mt-4 text-slate-300">
+          Fondée en 2010 par le Très Révérend Apôtre Julius EKIE, notre communauté est née du désir d'apporter l'espérance et la lumière de l'Évangile au plus grand nombre.
+        </p>
+      </div>
+    </section>
+
+    <section className="mx-auto max-w-6xl px-6 py-16">
+      <h2 className="section-title">Notre Équipe Pastorale</h2>
+      <div className="mt-6 grid gap-6 md:grid-cols-3">
+        {[
+          { name: 'Apôtre Julius EKIE', role: 'Fondateur et visionnaire de TFMI.', photo: '/assets/pastor-apostle.svg' },
+          { name: 'Pasteur Pierre', role: "Responsable de l'enseignement biblique.", photo: '/assets/pastor-apostle.svg' },
+          { name: 'Pasteur Marie', role: 'En charge du ministère de la louange.', photo: '/assets/pastor-apostle.svg' }
+        ].map((member) => (
+          <div key={member.name} className="card text-center">
+            <img src={member.photo} alt={member.name} className="mx-auto h-40 w-40 rounded-full object-cover" />
+            <h3 className="mt-4 text-lg font-semibold">{member.name}</h3>
+            <p className="text-sm text-slate-400">{member.role}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+
+    <section className="bg-slate-900/60">
+      <div className="mx-auto max-w-6xl px-6 py-16">
+        <h2 className="section-title">Message du Fondateur</h2>
+        <p className="mt-4 text-slate-300">
+          Bienvenue à TFMI. Mon souhait est que chaque personne qui franchit nos portes rencontre Jésus-Christ et découvre la puissance transformante de sa grâce.
+        </p>
+      </div>
+    </section>
+  </Layout>
+);
+
+export default About;

--- a/frontend/src/pages/Contact.jsx
+++ b/frontend/src/pages/Contact.jsx
@@ -1,0 +1,66 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { useState } from 'react';
+import Layout from '../components/Layout';
+import Meta from '../components/Meta';
+import { submitContact } from '../api/resources';
+
+const schema = z.object({
+  name: z.string().min(2, 'Nom requis'),
+  email: z.string().email('Email invalide'),
+  message: z.string().min(10, 'Message requis')
+});
+
+const Contact = () => {
+  const [status, setStatus] = useState(null);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    reset
+  } = useForm({ resolver: zodResolver(schema) });
+
+  const onSubmit = async (values) => {
+    try {
+      await submitContact(values);
+      setStatus('Message envoyé avec succès.');
+      reset();
+    } catch (error) {
+      setStatus(\"Impossible d'envoyer le message.\");
+    }
+  };
+
+  return (
+    <Layout>
+      <Meta title="TFMI - Contact" description="Contactez la communauté TFMI" />
+      <section className="mx-auto max-w-4xl px-6 py-16">
+        <h1 className="section-title">Contact</h1>
+        <p className="mt-4 text-slate-300">Écrivez-nous pour toute demande ou prière.</p>
+        <form onSubmit={handleSubmit(onSubmit)} className="mt-8 space-y-4">
+          <label className="block">
+            <span className="text-sm text-slate-400">Nom complet</span>
+            <input className="input" {...register('name')} />
+            {errors.name && <p className="text-sm text-red-400">{errors.name.message}</p>}
+          </label>
+          <label className="block">
+            <span className="text-sm text-slate-400">Email</span>
+            <input className="input" type="email" {...register('email')} />
+            {errors.email && <p className="text-sm text-red-400">{errors.email.message}</p>}
+          </label>
+          <label className="block">
+            <span className="text-sm text-slate-400">Message</span>
+            <textarea className="input min-h-[160px]" {...register('message')} />
+            {errors.message && <p className="text-sm text-red-400">{errors.message.message}</p>}
+          </label>
+          <button type="submit" className="button-primary" disabled={isSubmitting}>
+            {isSubmitting ? 'Envoi...' : 'Envoyer'}
+          </button>
+          {status && <p className="text-sm text-secondary">{status}</p>}
+        </form>
+      </section>
+    </Layout>
+  );
+};
+
+export default Contact;

--- a/frontend/src/pages/Don.jsx
+++ b/frontend/src/pages/Don.jsx
@@ -1,0 +1,31 @@
+import Layout from '../components/Layout';
+import Meta from '../components/Meta';
+
+const Don = () => (
+  <Layout>
+    <Meta title="TFMI - Don" description="Soutenir la mission TFMI" />
+    <section className="mx-auto max-w-4xl space-y-6 px-6 py-16">
+      <h1 className="section-title">Don & Offrandes</h1>
+      <p className="text-slate-300">
+        Votre générosité soutient la mission, l'action sociale et l'expansion de l'Évangile.
+        Merci pour votre engagement.
+      </p>
+      <div className="card">
+        <h2 className="text-lg font-semibold">Comment donner ?</h2>
+        <p className="text-slate-300">
+          Les informations de don peuvent être configurées par l'équipe administrative.
+        </p>
+        <a
+          href="https://example.com/donation"
+          target="_blank"
+          rel="noreferrer"
+          className="button-primary mt-4"
+        >
+          Accéder au lien de don
+        </a>
+      </div>
+    </section>
+  </Layout>
+);
+
+export default Don;

--- a/frontend/src/pages/EventDetail.jsx
+++ b/frontend/src/pages/EventDetail.jsx
@@ -1,0 +1,34 @@
+import { useParams, Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import Layout from '../components/Layout';
+import Meta from '../components/Meta';
+import { fetchEvent } from '../api/resources';
+
+const EventDetail = () => {
+  const { id } = useParams();
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['event', id],
+    queryFn: () => fetchEvent(id)
+  });
+
+  return (
+    <Layout>
+      <Meta title="TFMI - Détail événement" />
+      <section className="mx-auto max-w-3xl px-6 py-16">
+        <Link to="/events" className="text-secondary">← Retour</Link>
+        {isLoading && <p className="mt-6">Chargement...</p>}
+        {error && <p className="mt-6 text-red-400">Impossible de charger.</p>}
+        {data && (
+          <div className="mt-6 space-y-4">
+            <h1 className="section-title">{data.title}</h1>
+            <p className="text-sm text-slate-400">{new Date(data.date).toLocaleDateString('fr-FR')}</p>
+            <p className="text-slate-300">{data.description}</p>
+            <p className="text-secondary">{data.location}</p>
+          </div>
+        )}
+      </section>
+    </Layout>
+  );
+};
+
+export default EventDetail;

--- a/frontend/src/pages/Events.jsx
+++ b/frontend/src/pages/Events.jsx
@@ -1,0 +1,37 @@
+import { Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import Layout from '../components/Layout';
+import Meta from '../components/Meta';
+import { fetchEvents } from '../api/resources';
+
+const Events = () => {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['events'],
+    queryFn: () => fetchEvents({ page: 1, limit: 10, published: true })
+  });
+
+  return (
+    <Layout>
+      <Meta title="TFMI - Événements" description="Agenda des événements TFMI" />
+      <section className="mx-auto max-w-6xl px-6 py-16">
+        <h1 className="section-title">Événements</h1>
+        {isLoading && <p className="mt-6">Chargement...</p>}
+        {error && <p className="mt-6 text-red-400">Impossible de charger les événements.</p>}
+        <div className="mt-8 grid gap-6 md:grid-cols-2">
+          {data?.items?.map((event) => (
+            <article key={event._id} className="card">
+              <h2 className="text-xl font-semibold">{event.title}</h2>
+              <p className="text-sm text-slate-400">{new Date(event.date).toLocaleDateString('fr-FR')}</p>
+              <p className="mt-2 text-slate-300 line-clamp-3">{event.description}</p>
+              <Link to={`/events/${event._id}`} className="mt-4 inline-block text-secondary">
+                Voir le détail
+              </Link>
+            </article>
+          ))}
+        </div>
+      </section>
+    </Layout>
+  );
+};
+
+export default Events;

--- a/frontend/src/pages/Gallery.jsx
+++ b/frontend/src/pages/Gallery.jsx
@@ -1,0 +1,32 @@
+import { useQuery } from '@tanstack/react-query';
+import Layout from '../components/Layout';
+import Meta from '../components/Meta';
+import { fetchGallery } from '../api/resources';
+
+const Gallery = () => {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['gallery'],
+    queryFn: () => fetchGallery({ page: 1, limit: 20, published: true })
+  });
+
+  return (
+    <Layout>
+      <Meta title="TFMI - Galerie" description="Photos de la communauté TFMI" />
+      <section className="mx-auto max-w-6xl px-6 py-16">
+        <h1 className="section-title">Galerie</h1>
+        {isLoading && <p className="mt-6">Chargement...</p>}
+        {error && <p className="mt-6 text-red-400">Impossible de charger la galerie.</p>}
+        <div className="mt-8 grid gap-6 sm:grid-cols-2 md:grid-cols-3">
+          {data?.items?.map((item) => (
+            <figure key={item._id} className="card">
+              <img src={item.imageUrl} alt={item.title} className="h-48 w-full rounded-xl object-cover" />
+              <figcaption className="mt-3 text-sm text-slate-300">{item.title}</figcaption>
+            </figure>
+          ))}
+        </div>
+      </section>
+    </Layout>
+  );
+};
+
+export default Gallery;

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,0 +1,145 @@
+import { useQuery } from '@tanstack/react-query';
+import Layout from '../components/Layout';
+import Meta from '../components/Meta';
+import { fetchEvents, fetchSermons, fetchPosts } from '../api/resources';
+
+const Home = () => {
+  const eventsQuery = useQuery({
+    queryKey: ['events', 'home'],
+    queryFn: () => fetchEvents({ page: 1, limit: 3, published: true })
+  });
+  const sermonsQuery = useQuery({
+    queryKey: ['sermons', 'home'],
+    queryFn: () => fetchSermons({ page: 1, limit: 1, published: true })
+  });
+  const postsQuery = useQuery({
+    queryKey: ['posts', 'home'],
+    queryFn: () => fetchPosts({ page: 1, limit: 2, published: true })
+  });
+
+  const latestSermon = sermonsQuery.data?.items?.[0];
+
+  return (
+    <Layout>
+      <Meta title="TFMI - Accueil" description="Triumphant Faith Ministries - ensemble vers la victoire en Christ" />
+      <section className="relative overflow-hidden bg-slate-900">
+        <div className="absolute inset-0">
+          <img
+            src="/assets/hero.svg"
+            alt="Communauté TFMI"
+            className="h-full w-full object-cover opacity-30"
+          />
+        </div>
+        <div className="relative mx-auto flex max-w-6xl flex-col gap-6 px-6 py-24">
+          <p className="text-sm uppercase tracking-widest text-secondary">Triumphant Faith Ministries</p>
+          <h1 className="text-4xl font-semibold md:text-5xl">
+            Ensemble vers la victoire en Christ
+          </h1>
+          <p className="max-w-2xl text-lg text-slate-300">
+            Nous sommes une communauté dédiée à la foi, à l'amour et à la puissance de l'Évangile.
+          </p>
+          <div className="flex flex-wrap gap-4">
+            <a href="/events" className="button-primary">Nos événements</a>
+            <a href="/contact" className="button-outline">Nous contacter</a>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl space-y-10 px-6 py-16">
+        <div className="grid gap-6 md:grid-cols-2">
+          <div className="space-y-4">
+            <h2 className="section-title">Bienvenue</h2>
+            <p className="text-slate-300">
+              Nous sommes heureux de vous accueillir sur le site de Triumphant Faith Ministries. Que la paix du Seigneur soit avec vous.
+            </p>
+            <blockquote className="border-l-4 border-secondary pl-4 text-slate-400">
+              « Il a dépouillé les dominations et les autorités, et les a livrées publiquement en spectacle, en triomphant d'elles par la croix. » (Colossiens 2:15)
+            </blockquote>
+          </div>
+          <img
+            src="/assets/community.svg"
+            alt="Photo de la communauté"
+            className="h-72 w-full rounded-2xl object-cover"
+          />
+        </div>
+      </section>
+
+      <section className="bg-slate-900/50">
+        <div className="mx-auto max-w-6xl space-y-8 px-6 py-16">
+          <h2 className="section-title">Prochains événements</h2>
+          {eventsQuery.isLoading && <p>Chargement...</p>}
+          {eventsQuery.error && <p className="text-red-400">Impossible de charger les événements.</p>}
+          <div className="grid gap-6 md:grid-cols-3">
+            {eventsQuery.data?.items?.map((event) => (
+              <article key={event._id} className="card">
+                <h3 className="text-lg font-semibold">{event.title}</h3>
+                <p className="text-sm text-slate-400">{new Date(event.date).toLocaleDateString('fr-FR')}</p>
+                <p className="mt-2 text-sm text-slate-300 line-clamp-3">{event.description}</p>
+                <p className="mt-4 text-xs uppercase text-secondary">{event.location}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl space-y-8 px-6 py-16">
+        <div className="grid gap-8 md:grid-cols-2">
+          <div className="card">
+            <h2 className="section-title">Dernier sermon</h2>
+            {latestSermon ? (
+              <div className="mt-4 space-y-2">
+                <p className="text-lg font-semibold">{latestSermon.title}</p>
+                <p className="text-sm text-slate-400">{latestSermon.preacher}</p>
+                <p className="text-slate-300">{latestSermon.description}</p>
+                {latestSermon.mediaUrl && (
+                  <a href={latestSermon.mediaUrl} className="button-outline" target="_blank" rel="noreferrer">
+                    Regarder
+                  </a>
+                )}
+              </div>
+            ) : (
+              <p>Aucun sermon disponible.</p>
+            )}
+          </div>
+          <div className="card">
+            <h2 className="section-title">Actualités</h2>
+            <div className="mt-4 space-y-3">
+              {postsQuery.data?.items?.map((post) => (
+                <div key={post._id}>
+                  <p className="font-semibold">{post.title}</p>
+                  <p className="text-sm text-slate-400 line-clamp-2">{post.content}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-slate-900/60">
+        <div className="mx-auto max-w-6xl px-6 py-16">
+          <h2 className="section-title">Infos pratiques</h2>
+          <div className="mt-6 grid gap-6 md:grid-cols-3">
+            <div className="card">
+              <h3 className="text-lg font-semibold">Horaires</h3>
+              <p className="text-sm text-slate-400">Dimanche 09:00 - 12:00</p>
+              <p className="text-sm text-slate-400">Mardi 18:00 - 20:00</p>
+              <p className="text-sm text-slate-400">Jeudi 18:30 - 20:30</p>
+            </div>
+            <div className="card">
+              <h3 className="text-lg font-semibold">Adresse principale</h3>
+              <p className="text-sm text-slate-400">Mbog Abang, Yaoundé</p>
+              <p className="text-sm text-slate-400">+237 XXX XXX XXX</p>
+            </div>
+            <div className="card">
+              <h3 className="text-lg font-semibold">Besoin d'aide ?</h3>
+              <p className="text-sm text-slate-400">contact@tfmi.org</p>
+              <a href="/contact" className="button-outline mt-3">Écrire</a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </Layout>
+  );
+};
+
+export default Home;

--- a/frontend/src/pages/Ministries.jsx
+++ b/frontend/src/pages/Ministries.jsx
@@ -1,0 +1,41 @@
+import { useQuery } from '@tanstack/react-query';
+import Layout from '../components/Layout';
+import Meta from '../components/Meta';
+import { fetchMinistries } from '../api/resources';
+
+const Ministries = () => {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['ministries'],
+    queryFn: () => fetchMinistries({ page: 1, limit: 20, published: true })
+  });
+
+  return (
+    <Layout>
+      <Meta title="TFMI - Ministères" description="Les ministères et départements de TFMI" />
+      <section className="mx-auto max-w-6xl px-6 py-16">
+        <h1 className="section-title">Ministères & Départements</h1>
+        {isLoading && <p className="mt-6">Chargement...</p>}
+        {error && <p className="mt-6 text-red-400">Impossible de charger les ministères.</p>}
+        <div className="mt-8 grid gap-6 md:grid-cols-2">
+          {data?.items?.map((ministry) => (
+            <div key={ministry._id} className="card">
+              <img
+                src={ministry.image || '/assets/ministry.svg'}
+                alt={ministry.name}
+                className="h-40 w-full rounded-xl object-cover"
+              />
+              <h2 className="mt-4 text-xl font-semibold">{ministry.name}</h2>
+              <p className="text-sm text-slate-400">Responsable : {ministry.leader}</p>
+              <p className="mt-2 text-slate-300">{ministry.description}</p>
+              {ministry.schedule && (
+                <p className="mt-2 text-xs uppercase text-secondary">{ministry.schedule}</p>
+              )}
+            </div>
+          ))}
+        </div>
+      </section>
+    </Layout>
+  );
+};
+
+export default Ministries;

--- a/frontend/src/pages/PostDetail.jsx
+++ b/frontend/src/pages/PostDetail.jsx
@@ -1,0 +1,41 @@
+import { useParams, Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import Layout from '../components/Layout';
+import Meta from '../components/Meta';
+import { fetchPost } from '../api/resources';
+
+const PostDetail = () => {
+  const { id } = useParams();
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['post', id],
+    queryFn: () => fetchPost(id)
+  });
+
+  return (
+    <Layout>
+      <Meta title="TFMI - Actualité" />
+      <section className="mx-auto max-w-3xl px-6 py-16">
+        <Link to="/posts" className="text-secondary">← Retour</Link>
+        {isLoading && <p className="mt-6">Chargement...</p>}
+        {error && <p className="mt-6 text-red-400">Impossible de charger.</p>}
+        {data && (
+          <div className="mt-6 space-y-4">
+            <h1 className="section-title">{data.title}</h1>
+            <p className="text-slate-300">{data.content}</p>
+            {data.tags?.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {data.tags.map((tag) => (
+                  <span key={tag} className="rounded-full bg-secondary/20 px-3 py-1 text-xs text-secondary">
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </section>
+    </Layout>
+  );
+};
+
+export default PostDetail;

--- a/frontend/src/pages/Posts.jsx
+++ b/frontend/src/pages/Posts.jsx
@@ -1,0 +1,36 @@
+import { Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import Layout from '../components/Layout';
+import Meta from '../components/Meta';
+import { fetchPosts } from '../api/resources';
+
+const Posts = () => {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['posts'],
+    queryFn: () => fetchPosts({ page: 1, limit: 10, published: true })
+  });
+
+  return (
+    <Layout>
+      <Meta title="TFMI - Actualités" description="Annonces et actualités TFMI" />
+      <section className="mx-auto max-w-6xl px-6 py-16">
+        <h1 className="section-title">Actualités & Annonces</h1>
+        {isLoading && <p className="mt-6">Chargement...</p>}
+        {error && <p className="mt-6 text-red-400">Impossible de charger les actualités.</p>}
+        <div className="mt-8 grid gap-6 md:grid-cols-2">
+          {data?.items?.map((post) => (
+            <article key={post._id} className="card">
+              <h2 className="text-xl font-semibold">{post.title}</h2>
+              <p className="mt-2 text-slate-300 line-clamp-3">{post.content}</p>
+              <Link to={`/posts/${post._id}`} className="mt-4 inline-block text-secondary">
+                Lire l'annonce
+              </Link>
+            </article>
+          ))}
+        </div>
+      </section>
+    </Layout>
+  );
+};
+
+export default Posts;

--- a/frontend/src/pages/SermonDetail.jsx
+++ b/frontend/src/pages/SermonDetail.jsx
@@ -1,0 +1,39 @@
+import { useParams, Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import Layout from '../components/Layout';
+import Meta from '../components/Meta';
+import { fetchSermon } from '../api/resources';
+
+const SermonDetail = () => {
+  const { id } = useParams();
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['sermon', id],
+    queryFn: () => fetchSermon(id)
+  });
+
+  return (
+    <Layout>
+      <Meta title="TFMI - Sermon" />
+      <section className="mx-auto max-w-3xl px-6 py-16">
+        <Link to="/sermons" className="text-secondary">← Retour</Link>
+        {isLoading && <p className="mt-6">Chargement...</p>}
+        {error && <p className="mt-6 text-red-400">Impossible de charger.</p>}
+        {data && (
+          <div className="mt-6 space-y-4">
+            <h1 className="section-title">{data.title}</h1>
+            <p className="text-sm text-slate-400">{data.preacher}</p>
+            <p className="text-slate-300">{data.description}</p>
+            {data.notes && <p className="text-sm text-slate-400">Notes: {data.notes}</p>}
+            {data.mediaUrl && (
+              <a href={data.mediaUrl} target="_blank" rel="noreferrer" className="button-outline">
+                Voir la vidéo / audio
+              </a>
+            )}
+          </div>
+        )}
+      </section>
+    </Layout>
+  );
+};
+
+export default SermonDetail;

--- a/frontend/src/pages/Sermons.jsx
+++ b/frontend/src/pages/Sermons.jsx
@@ -1,0 +1,37 @@
+import { Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import Layout from '../components/Layout';
+import Meta from '../components/Meta';
+import { fetchSermons } from '../api/resources';
+
+const Sermons = () => {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['sermons'],
+    queryFn: () => fetchSermons({ page: 1, limit: 10, published: true })
+  });
+
+  return (
+    <Layout>
+      <Meta title="TFMI - Sermons" description="Sermons et enseignements" />
+      <section className="mx-auto max-w-6xl px-6 py-16">
+        <h1 className="section-title">Sermons & Enseignements</h1>
+        {isLoading && <p className="mt-6">Chargement...</p>}
+        {error && <p className="mt-6 text-red-400">Impossible de charger les sermons.</p>}
+        <div className="mt-8 grid gap-6 md:grid-cols-2">
+          {data?.items?.map((sermon) => (
+            <article key={sermon._id} className="card">
+              <h2 className="text-xl font-semibold">{sermon.title}</h2>
+              <p className="text-sm text-slate-400">{sermon.preacher}</p>
+              <p className="mt-2 text-slate-300 line-clamp-3">{sermon.description}</p>
+              <Link to={`/sermons/${sermon._id}`} className="mt-4 inline-block text-secondary">
+                Lire la suite
+              </Link>
+            </article>
+          ))}
+        </div>
+      </section>
+    </Layout>
+  );
+};
+
+export default Sermons;

--- a/frontend/src/pages/admin/Dashboard.jsx
+++ b/frontend/src/pages/admin/Dashboard.jsx
@@ -1,0 +1,19 @@
+import { useAuth } from '../../hooks/useAuth';
+
+const Dashboard = () => {
+  const { user, signOut } = useAuth();
+
+  return (
+    <section className="space-y-4">
+      <h2 className="text-xl font-semibold">Bienvenue {user?.email || 'Admin'}</h2>
+      <p className="text-slate-300">
+        Gérez les événements, sermons, annonces et contenus médias depuis ce tableau de bord.
+      </p>
+      <button type="button" className="button-outline" onClick={signOut}>
+        Se déconnecter
+      </button>
+    </section>
+  );
+};
+
+export default Dashboard;

--- a/frontend/src/pages/admin/EventsAdmin.jsx
+++ b/frontend/src/pages/admin/EventsAdmin.jsx
@@ -1,0 +1,18 @@
+import ResourceManager from '../../components/admin/ResourceManager';
+
+const EventsAdmin = () => (
+  <ResourceManager
+    resource="events"
+    title="Gestion des événements"
+    fields={[
+      { name: 'title', label: 'Titre', type: 'text' },
+      { name: 'description', label: 'Description', type: 'textarea' },
+      { name: 'date', label: 'Date', type: 'datetime-local' },
+      { name: 'location', label: 'Lieu', type: 'text' },
+      { name: 'image', label: 'Image', type: 'file' },
+      { name: 'published', label: 'Publié', type: 'checkbox' }
+    ]}
+  />
+);
+
+export default EventsAdmin;

--- a/frontend/src/pages/admin/GalleryAdmin.jsx
+++ b/frontend/src/pages/admin/GalleryAdmin.jsx
@@ -1,0 +1,15 @@
+import ResourceManager from '../../components/admin/ResourceManager';
+
+const GalleryAdmin = () => (
+  <ResourceManager
+    resource="gallery"
+    title="Gestion de la galerie"
+    fields={[
+      { name: 'title', label: 'Titre', type: 'text' },
+      { name: 'imageUrl', label: 'Image', type: 'file' },
+      { name: 'published', label: 'Publié', type: 'checkbox' }
+    ]}
+  />
+);
+
+export default GalleryAdmin;

--- a/frontend/src/pages/admin/Login.jsx
+++ b/frontend/src/pages/admin/Login.jsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../hooks/useAuth';
+import Meta from '../../components/Meta';
+
+const Login = () => {
+  const navigate = useNavigate();
+  const { signIn } = useAuth();
+  const [error, setError] = useState('');
+  const [form, setForm] = useState({ email: '', password: '' });
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setError('');
+    try {
+      await signIn(form);
+      navigate('/admin');
+    } catch (err) {
+      setError('Identifiants invalides');
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-950 px-6 text-slate-100">
+      <Meta title="TFMI - Admin Login" />
+      <form onSubmit={handleSubmit} className="card w-full max-w-md space-y-4">
+        <h1 className="text-2xl font-semibold">Connexion admin</h1>
+        <label className="block">
+          <span className="text-sm text-slate-400">Email</span>
+          <input
+            className="input"
+            type="email"
+            value={form.email}
+            onChange={(event) => setForm((prev) => ({ ...prev, email: event.target.value }))}
+            required
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm text-slate-400">Mot de passe</span>
+          <input
+            className="input"
+            type="password"
+            value={form.password}
+            onChange={(event) => setForm((prev) => ({ ...prev, password: event.target.value }))}
+            required
+          />
+        </label>
+        {error && <p className="text-sm text-red-400">{error}</p>}
+        <button type="submit" className="button-primary w-full">
+          Se connecter
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default Login;

--- a/frontend/src/pages/admin/MinistriesAdmin.jsx
+++ b/frontend/src/pages/admin/MinistriesAdmin.jsx
@@ -1,0 +1,18 @@
+import ResourceManager from '../../components/admin/ResourceManager';
+
+const MinistriesAdmin = () => (
+  <ResourceManager
+    resource="ministries"
+    title="Gestion des ministères"
+    fields={[
+      { name: 'name', label: 'Nom', type: 'text' },
+      { name: 'description', label: 'Description', type: 'textarea' },
+      { name: 'leader', label: 'Responsable', type: 'text' },
+      { name: 'schedule', label: 'Horaire', type: 'text' },
+      { name: 'image', label: 'Image', type: 'file' },
+      { name: 'published', label: 'Publié', type: 'checkbox' }
+    ]}
+  />
+);
+
+export default MinistriesAdmin;

--- a/frontend/src/pages/admin/PostsAdmin.jsx
+++ b/frontend/src/pages/admin/PostsAdmin.jsx
@@ -1,0 +1,17 @@
+import ResourceManager from '../../components/admin/ResourceManager';
+
+const PostsAdmin = () => (
+  <ResourceManager
+    resource="posts"
+    title="Gestion des annonces"
+    fields={[
+      { name: 'title', label: 'Titre', type: 'text' },
+      { name: 'content', label: 'Contenu', type: 'textarea' },
+      { name: 'coverImage', label: 'Image de couverture', type: 'file' },
+      { name: 'tags', label: 'Tags (séparés par virgules)', type: 'text' },
+      { name: 'published', label: 'Publié', type: 'checkbox' }
+    ]}
+  />
+);
+
+export default PostsAdmin;

--- a/frontend/src/pages/admin/SermonsAdmin.jsx
+++ b/frontend/src/pages/admin/SermonsAdmin.jsx
@@ -1,0 +1,19 @@
+import ResourceManager from '../../components/admin/ResourceManager';
+
+const SermonsAdmin = () => (
+  <ResourceManager
+    resource="sermons"
+    title="Gestion des sermons"
+    fields={[
+      { name: 'title', label: 'Titre', type: 'text' },
+      { name: 'preacher', label: 'Prédicateur', type: 'text' },
+      { name: 'date', label: 'Date', type: 'datetime-local' },
+      { name: 'description', label: 'Description', type: 'textarea' },
+      { name: 'mediaUrl', label: 'Lien média', type: 'text' },
+      { name: 'notes', label: 'Notes', type: 'textarea' },
+      { name: 'published', label: 'Publié', type: 'checkbox' }
+    ]}
+  />
+);
+
+export default SermonsAdmin;

--- a/frontend/src/pages/admin/TeamAdmin.jsx
+++ b/frontend/src/pages/admin/TeamAdmin.jsx
@@ -1,0 +1,18 @@
+import ResourceManager from '../../components/admin/ResourceManager';
+
+const TeamAdmin = () => (
+  <ResourceManager
+    resource="team"
+    title="Gestion de l'équipe"
+    fields={[
+      { name: 'name', label: 'Nom', type: 'text' },
+      { name: 'roleTitle', label: 'Rôle', type: 'text' },
+      { name: 'bio', label: 'Biographie', type: 'textarea' },
+      { name: 'photo', label: 'Photo', type: 'file' },
+      { name: 'order', label: 'Ordre', type: 'number' },
+      { name: 'published', label: 'Publié', type: 'checkbox' }
+    ]}
+  />
+);
+
+export default TeamAdmin;

--- a/frontend/src/routes/App.jsx
+++ b/frontend/src/routes/App.jsx
@@ -1,0 +1,55 @@
+import { Routes, Route } from 'react-router-dom';
+import Home from '../pages/Home';
+import About from '../pages/About';
+import Ministries from '../pages/Ministries';
+import Events from '../pages/Events';
+import EventDetail from '../pages/EventDetail';
+import Sermons from '../pages/Sermons';
+import SermonDetail from '../pages/SermonDetail';
+import Gallery from '../pages/Gallery';
+import Posts from '../pages/Posts';
+import PostDetail from '../pages/PostDetail';
+import Contact from '../pages/Contact';
+import Don from '../pages/Don';
+import Login from '../pages/admin/Login';
+import Dashboard from '../pages/admin/Dashboard';
+import EventsAdmin from '../pages/admin/EventsAdmin';
+import SermonsAdmin from '../pages/admin/SermonsAdmin';
+import PostsAdmin from '../pages/admin/PostsAdmin';
+import MinistriesAdmin from '../pages/admin/MinistriesAdmin';
+import TeamAdmin from '../pages/admin/TeamAdmin';
+import GalleryAdmin from '../pages/admin/GalleryAdmin';
+import AdminLayout from '../components/admin/AdminLayout';
+import ProtectedRoute from './ProtectedRoute';
+
+const App = () => (
+  <Routes>
+    <Route path="/" element={<Home />} />
+    <Route path="/about" element={<About />} />
+    <Route path="/ministries" element={<Ministries />} />
+    <Route path="/events" element={<Events />} />
+    <Route path="/events/:id" element={<EventDetail />} />
+    <Route path="/sermons" element={<Sermons />} />
+    <Route path="/sermons/:id" element={<SermonDetail />} />
+    <Route path="/gallery" element={<Gallery />} />
+    <Route path="/posts" element={<Posts />} />
+    <Route path="/posts/:id" element={<PostDetail />} />
+    <Route path="/contact" element={<Contact />} />
+    <Route path="/don" element={<Don />} />
+
+    <Route path="/admin/login" element={<Login />} />
+    <Route element={<ProtectedRoute />}>
+      <Route element={<AdminLayout />}>
+        <Route path="/admin" element={<Dashboard />} />
+        <Route path="/admin/events" element={<EventsAdmin />} />
+        <Route path="/admin/sermons" element={<SermonsAdmin />} />
+        <Route path="/admin/posts" element={<PostsAdmin />} />
+        <Route path="/admin/ministries" element={<MinistriesAdmin />} />
+        <Route path="/admin/team" element={<TeamAdmin />} />
+        <Route path="/admin/gallery" element={<GalleryAdmin />} />
+      </Route>
+    </Route>
+  </Routes>
+);
+
+export default App;

--- a/frontend/src/routes/ProtectedRoute.jsx
+++ b/frontend/src/routes/ProtectedRoute.jsx
@@ -1,0 +1,11 @@
+import { Navigate, Outlet } from 'react-router-dom';
+
+const ProtectedRoute = () => {
+  const token = localStorage.getItem('tfmi_token');
+  if (!token) {
+    return <Navigate to="/admin/login" replace />;
+  }
+  return <Outlet />;
+};
+
+export default ProtectedRoute;

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -1,0 +1,27 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  font-family: 'Poppins', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+.section-title {
+  @apply text-3xl font-semibold text-white;
+}
+
+.card {
+  @apply bg-slate-900/70 border border-slate-800 rounded-2xl p-6 shadow-lg;
+}
+
+.input {
+  @apply w-full rounded-xl border border-slate-700 bg-slate-900 px-4 py-3 text-white focus:border-secondary focus:outline-none focus:ring-2 focus:ring-secondary/40;
+}
+
+.button-primary {
+  @apply inline-flex items-center justify-center rounded-full bg-secondary px-6 py-3 font-semibold text-slate-900 transition hover:bg-secondary/90;
+}
+
+.button-outline {
+  @apply inline-flex items-center justify-center rounded-full border border-white/40 px-6 py-3 font-semibold text-white transition hover:border-secondary hover:text-secondary;
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,12 @@
+export default {
+  content: ['./index.html', './src/**/*.{js,jsx}'],
+  theme: {
+    extend: {
+      colors: {
+        primary: '#1f6b4c',
+        secondary: '#f0b429'
+      }
+    }
+  },
+  plugins: []
+};

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "tfmi-mern",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "concurrently \"npm --prefix backend run dev\" \"npm --prefix frontend run dev\"",
+    "backend": "npm --prefix backend run dev",
+    "frontend": "npm --prefix frontend run dev"
+  },
+  "devDependencies": {
+    "concurrently": "^8.2.2"
+  }
+}


### PR DESCRIPTION
### Motivation
- Remove binary JPG assets from the repository and replace them with lightweight SVG placeholders to avoid committing large/binary files and to satisfy repo constraints. 
- Ensure the frontend and backend seed data point to existing assets so pages and seeded demo content render without missing-file errors. 

### Description
- Deleted the old `frontend/public/assets/*.jpg` files and added SVG placeholders: `logo.svg`, `hero.svg`, `community.svg`, `ministry.svg`, `pastor-apostle.svg`, and `prayer.svg`. 
- Updated frontend code to use the new SVGs (`Navbar`, `Home`, `About`, `Ministries` and other pages now reference the SVG paths). 
- Updated backend seed data in `backend/src/utils/seed.js` to point to the new SVG asset paths and documented the change in `README.md`. 

### Testing
- No automated tests were executed as part of this change because it is asset-focused and non-functional; unit/API tests remain available and can be run with `npm --prefix backend test`. 
- Verified locally that all code references to the removed JPG filenames were replaced (search/replace) and that the new SVG assets are present under `frontend/public/assets`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e2159bc2c832b942fea8f55b8c858)